### PR TITLE
Add libffi to Alpine Linux Python images

### DIFF
--- a/alpine/python.dockerfile
+++ b/alpine/python.dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
 # ca-certificates not installed in Alpine Python images for some reason:
 # https://github.com/docker-library/python/issues/109
-RUN apk add --no-cache ca-certificates
+# Also install libffi as it is required by cffi and present in the Debian images
+RUN apk add --no-cache ca-certificates libffi
 
 # pip: Disable cache and use Praekelt Foundation Python Package Index
 ENV PIP_NO_CACHE_DIR="false" \

--- a/alpine/python3.dockerfile
+++ b/alpine/python3.dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
 # ca-certificates not installed in Alpine Python images for some reason:
 # https://github.com/docker-library/python/issues/109
-RUN apk add --no-cache ca-certificates
+# Also install libffi as it is required by cffi and present in the Debian images
+RUN apk add --no-cache ca-certificates libffi
 
 # pip: Disable cache and use Praekelt Foundation Python Package Index
 ENV PIP_NO_CACHE_DIR="false" \


### PR DESCRIPTION
Commonly used with `cffi`. Debian images have this installed already as a dependency. Adds only ~300KB to uncompressed image.