### PR TITLE
Add script to detect and install libraries needed by Python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,9 @@ This problem will only apply in certain circumstances when using Docker volumes.
 
 ##### Our solution:
 A *hack*. The [`create-volume-user.sh`](debian/scripts/create-volume-user.sh) script can create a user and group with UID/GID that match those of the volume owner. This must happen at container runtime as the UID/GID of the volume can't be known before the volume is mounted.
+
+### Python package dependencies
+Installing the correct runtime native dependencies for Python packages is not always straightforward. For instance, a package like [`Pillow`](https://pypi.python.org/pypi/Pillow) has dependencies on a number of C libraries for working with images, such as [`libjpeg`](http://libjpeg.sourceforge.net) or [`libwebp`](https://chromium.googlesource.com/webm/libwebp). It's not always clear which libraries are required.
+
+#### Our solution:
+We build binary distributions of Python packages that we commonly use and host them in a PyPi repository. For more information, see [this repo](https://github.com/praekeltfoundation/debian-wheel-mirror). On our Alpine Linux images, we've added a script ([`install-py-pkg-deps.sh`](alpine/scripts/install-py-pkg-deps.sh)) that scans Python's site-packages directories for linked libraries and then installs the packages that provide those libraries.

--- a/alpine/python.dockerfile
+++ b/alpine/python.dockerfile
@@ -12,7 +12,7 @@ ENV PIP_NO_CACHE_DIR="false" \
 
 # Install utility scripts
 COPY ./common/scripts /scripts
-# COPY ./alpine/scripts /scripts
+COPY ./alpine/scripts /scripts
 ENV PATH $PATH:/scripts
 
 # Install dinit (dumb-init)

--- a/alpine/python3.dockerfile
+++ b/alpine/python3.dockerfile
@@ -12,7 +12,7 @@ ENV PIP_NO_CACHE_DIR="false" \
 
 # Install utility scripts
 COPY ./common/scripts /scripts
-# COPY ./alpine/scripts /scripts
+COPY ./alpine/scripts /scripts
 ENV PATH $PATH:/scripts
 
 # Install dinit (dumb-init)

--- a/alpine/scripts/install-py-pkg-deps.sh
+++ b/alpine/scripts/install-py-pkg-deps.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env sh
+set -e
+
+# Detects and installs the runtime dependencies of Python packages by
+# recursively scanning files in a directory and checking which libraries any
+# shared objects are linked against.
+#
+# Usage: ./install-py-pkg-deps.sh [PKG_DIRS...]
+#   PKG_DIRS should be paths to where the Python packages are located, for
+#   example, the path to the virtualenv. If not provided, the site-packages
+#   directories will be detected and used instead.
+
+PKG_DIRS="$@"
+
+site_packages() {
+  python <<EOM
+import site
+for dir in site.getsitepackages():
+  print(dir)
+EOM
+}
+
+if [ -z "$PKG_DIRS" ]; then
+  PKG_DIRS="$(site_packages)"
+fi
+
+find_not_installed_libs() {
+  # Find all the linked libraries in the provided directories. Parse them into
+  # a nice format, sort the unique ones, and remove libpython so that we don't
+  # install 2 Pythons.
+  local dep_libs="$(scanelf --needed --nobanner --recursive "$@" | \
+    awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' | \
+    sort -u | \
+    grep -v 'libpython')"
+
+  # Check whether each library is already installed or not.
+  local dep_lib
+  for dep_lib in $dep_libs; do
+    if ! apk info --installed "$dep_lib" &> /dev/null; then
+      echo "$dep_lib"
+    fi
+  done
+}
+
+# Find all the libraries in the directories
+DEP_LIBS="$(find_not_installed_libs $PKG_DIRS)"
+
+echo "Found $(echo "$DEP_LIBS" | wc -w) libraries that are not installed: \
+$(echo "$DEP_LIBS" | tr "\n" " ")"
+if [ -z "$DEP_LIBS" ]; then
+  echo "Nothing to do..."
+  exit 0
+fi
+
+# Use apk to find the packages for the libraries
+echo "Searching for packages..."
+# Fetch the package index - we need it twice: first for search then for add
+apk update
+DEP_PKGS="$(apk -q search $DEP_LIBS)"
+echo "Found $(echo "$DEP_PKGS" | wc -w) packages to install: \
+$(echo "$DEP_PKGS" | tr "\n" " ")"
+
+# Finally, install the packages
+apk add $DEP_PKGS
+
+# Clean up the apk index
+rm -rf /var/cache/apk/*
+
+# Double check that everything is installed
+DEP_LIBS="$(find_not_installed_libs $PKG_DIRS)"
+if [ -n "$DEP_LIBS" ]; then
+  echo "Unable to install packages for $(echo "$DEP_LIBS" | wc -w) libraries: \
+  $(echo "$DEP_LIBS" | tr "\n" " ")"
+  exit 1
+fi
+
+echo "All dependencies installed :-)"


### PR DESCRIPTION
* Only on Alpine Linux for now

```
/ # install-py-pkg-deps.sh
Found 0 libraries that are not installed:
Nothing to do...
/ # pip install Pillow
Collecting Pillow
  Downloading https://alpine-3.wheelhouse.praekelt.org/packages/Pillow-3.3.0-cp27-cp27mu-linux_x86_64.whl (821kB)
    100% |████████████████████████████████| 829kB 41kB/s
Installing collected packages: Pillow
Successfully installed Pillow-3.3.0
/ # install-py-pkg-deps.sh
Found 4 libraries that are not installed: so:libjpeg.so.8 so:libwebp.so.6 so:libwebpdemux.so.2 so:libwebpmux.so.2
Searching for packages...
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
v3.4.2-2-gd037d87 [http://dl-cdn.alpinelinux.org/alpine/v3.4/main]
v3.4.1-50-gd7c21d4 [http://dl-cdn.alpinelinux.org/alpine/v3.4/community]
OK: 5966 distinct packages available
Found 2 packages to install: libjpeg-turbo libwebp
(1/2) Installing libjpeg-turbo (1.4.2-r0)
(2/2) Installing libwebp (0.5.0-r0)
OK: 15 MiB in 22 packages
All dependencies installed :-)
/ #
```