### PR TITLE
Make PyPy available as python

### DIFF
--- a/debian/pypy.dockerfile
+++ b/debian/pypy.dockerfile
@@ -5,6 +5,9 @@ MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 ENV PIP_NO_CACHE_DIR="false" \
     PIP_EXTRA_INDEX_URL="https://jessie.wheelhouse.praekelt.org/simple"
 
+# Make PyPy available at /usr/bin/python for compatibility
+RUN update-alternatives --install /usr/bin/python python /usr/local/bin/pypy 50
+
 # Install utility scripts
 COPY ./common/scripts /scripts
 COPY ./debian/scripts /scripts


### PR DESCRIPTION
The `python` command should run PyPy on that image.