### PR TITLE
Alpine: ca-certificates now installed upstream

### DIFF
--- a/alpine/python.dockerfile
+++ b/alpine/python.dockerfile
@@ -1,11 +1,8 @@
 FROM python:2.7.12-alpine
 MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
-# ca-certificates not installed in Alpine Python images for some reason:
-# https://github.com/docker-library/python/issues/109
-# Also install libffi as it is required by cffi and present in the Debian images
+# Install libffi as it is required by cffi and present in the Debian images
 RUN apk add --no-cache \
-        ca-certificates \
         libffi \
         su-exec
 

--- a/alpine/python3.dockerfile
+++ b/alpine/python3.dockerfile
@@ -1,11 +1,8 @@
 FROM python:3.5.2-alpine
 MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
-# ca-certificates not installed in Alpine Python images for some reason:
-# https://github.com/docker-library/python/issues/109
-# Also install libffi as it is required by cffi and present in the Debian images
+# Install libffi as it is required by cffi and present in the Debian images
 RUN apk add --no-cache \
-        ca-certificates \
         libffi \
         su-exec
 


### PR DESCRIPTION
Fixed this in docker-library/python#136