### PR TITLE
PyPy2 5.6.0

### DIFF
--- a/debian/pypy.dockerfile
+++ b/debian/pypy.dockerfile
@@ -1,4 +1,4 @@
-FROM pypy:2-5.4.1-slim
+FROM pypy:2-5.6.0-slim
 MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
 # pip: Disable cache and use Praekelt Foundation Python Package Index


### PR DESCRIPTION
This will also trigger a rebuild of the other images which should get us:
* pip 9.0.1
* Upstream fix for CVE-2016-6321 tar "pointy feather" vulnerability